### PR TITLE
Fix license badge in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GemPBA tester
 
 [![C/C++ CI](https://github.com/rapastranac/gempba-tester/actions/workflows/c-cpp.yml/badge.svg)](https://github.com/rapastranac/gempba-tester/actions/workflows/c-cpp.yml)
-![GitHub License](https://img.shields.io/github/license/rapastranac/gempba)
+![GitHub License](https://img.shields.io/github/license/rapastranac/gempba-tester)
 ![GitHub Release](https://img.shields.io/github/v/release/rapastranac/gempba-tester)
 
 This is a collection of small programs to test the [**GemPBA**](https://github.com/rapastranac/gempba) library. I will


### PR DESCRIPTION
License badge was pointing to the wrong repository